### PR TITLE
Possible bug in self.scrollOffset initialization.

### DIFF
--- a/jquery.panelSnap.js
+++ b/jquery.panelSnap.js
@@ -410,7 +410,7 @@ if ( typeof Object.create !== 'function' ) {
       var self = this;
 
       // Gather scrollOffset for next scroll
-      self.scrollOffset = self.$container[0].scrollHeight;
+      self.scrollOffset = self.$snapContainer.scrollTop();
 
       self.enabled = true;
 


### PR DESCRIPTION
Shouldn't `scrollOffset` be initialized with the current `snapContainer` offset? 

With the current initialization (the scroll height of container[0]) I always get too large `scrollOffset` values which always cause the first scroll attempt to reset.
