### PR TITLE
Minor fixes in the scrolling logic.

### DIFF
--- a/jquery.panelSnap.js
+++ b/jquery.panelSnap.js
@@ -153,7 +153,6 @@ if ( typeof Object.create !== 'function' ) {
       }
 
       if(self.isMouseDown) {
-        self.$eventContainer.one('mouseup' + self.options.namespace, self.scrollStop);
         return;
       }
 
@@ -191,7 +190,7 @@ if ( typeof Object.create !== 'function' ) {
         // Only activate, prevent stuttering
         self.activatePanel($target);
         // Set scrollOffset to a sane number for next scroll
-        self.scrollOffset = offset < 0 ? 0 : maxOffset;
+        self.scrollOffset = offset <= 0 ? 0 : maxOffset;
       } else {
         self.snapToPanel($target);
       }
@@ -318,9 +317,8 @@ if ( typeof Object.create !== 'function' ) {
         self.options.onSnapFinish.call(self, $target);
         self.$container.trigger('panelsnap:finish', [$target]);
 
+        self.activatePanel($target);
       });
-
-      self.activatePanel($target);
 
     },
 


### PR DESCRIPTION
This PR fixes several minor issues in the snapping logic.
- Explicit `self.processScroll` handler registration is no longer needed in `scrollStop` at line 156 as the event will be triggered anyway by the `mouseUp` handler.
- Changing  the comparison from `<` to `<=` resolves an issue where the user scrolls to the very bottom and then to the very top of the container with the mouse.
- Finally, moving the `self.activatePanel($target);` at the end of the scroll callback ensures that any animations that might be triggered by an `onActivate` event are not interleaved with the auto-scroll trigegred by `snapToPanel`.
- Last, using `self.$snapContainer.scrollTop()` to gather the `scrollOffset` was already fixed by PR #37, but somehow was lost in the commit upon which I based these changes.
