### PR TITLE
Disable keypress events when panelsnap is disabled

### DIFF
--- a/jquery.panelSnap.js
+++ b/jquery.panelSnap.js
@@ -235,6 +235,10 @@ if ( typeof Object.create !== 'function' ) {
 
       var nav = self.options.keyboardNavigation;
 
+      if(!self.enabled) {
+        return;
+      }
+
       if (self.isSnapping) {
         if(e.which == nav.previousPanelKey || e.which == nav.nextPanelKey) {
           e.preventDefault();


### PR DESCRIPTION
If a panelsnap plugin is disabled (or toggled) any keypress events bound to it continues to cause the panels to snap as you can see in the **[plunker here](http://plnkr.co/edit/K2CqYup8daihYGi4pPw1?p=preview)**.

Not quite sure if this is deliberate but if not I have added the obvious fix.
