### PR TITLE
:eq() selector expects a zero-based index

### DIFF
--- a/jquery.panelSnap.js
+++ b/jquery.panelSnap.js
@@ -163,7 +163,7 @@ if ( typeof Object.create !== 'function' ) {
       var offset = self.$snapContainer.scrollTop();
       var scrollDifference = offset - self.scrollOffset;
       var maxOffset = self.$container[0].scrollHeight - self.scrollInterval;
-      var panelCount = self.getPanel().length;
+      var panelCount = self.getPanel().length - 1;
 
       var childNumber;
       if(


### PR DESCRIPTION
fixes getPanel not finding the last or first panel
