### PR TITLE
Sometimes markup gets in the way

### DIFF
--- a/jquery.panelSnap.js
+++ b/jquery.panelSnap.js
@@ -491,7 +491,7 @@ if ( typeof Object.create !== 'function' ) {
       previousPanelKey: 38,
       wrapAround: true
     },
-    strictContainerSelection: false
+    strictContainerSelection: true
   };
 
 })(jQuery, window, document);


### PR DESCRIPTION
It seems that, at the moment, there's a reliance that the scrolling container be a first degree parent to the elements that are being snapped to. I can't see how this is always (or even often) the case. I am using Bootstrap which unfortunately adds some crud between the body (which scrolls) and my sections so the `container + ' > ' + section` qualification really doesn't work. When you know that your 'section selector' is unique I don't see why there needs to be this qualification, especially if there's no dimensional difference between body and the layers between it and your section (though I haven't looked at exactly how the offset calculations are made).

I have added an option which switches off the direct descendant qualifier to fix this for me.
