### PR TITLE
Fix for JS scrolling in Chrome 61

### DIFF
--- a/jquery.panelSnap.js
+++ b/jquery.panelSnap.js
@@ -65,10 +65,10 @@ if ( typeof Object.create !== 'function' ) {
 
       if(self.$container.is('body')) {
         self.$eventContainer = $(document);
-        self.$snapContainer = $(document.documentElement);
+        self.$snapContainer = $(document.scrollingElement || document.documentElement);
 
         var ua = navigator.userAgent;
-        if(~ua.indexOf('WebKit')) {
+        if(~ua.indexOf('WebKit') && !~ua.indexOf('Chrome')) {
           self.$snapContainer = $('body');
         }
       }


### PR DESCRIPTION
Fixes #113. Prefer document.scrollingElement as the snap container in browsers that support it when the container is body, and don't overwrite it to be body in Chrome as Chrome 61 now supports this properly